### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/buildStyle.js
+++ b/scripts/buildStyle.js
@@ -260,7 +260,7 @@ function miniAttr(name) {
     return attrMap[name]
   }
 
-  return name.split('-').map(v => v.substr(0, 1) + v.substr(-1, 1)).join('')
+  return name.split('-').map(v => v.slice(0, 1) + v.slice(-1)).join('')
 }
 
 function zipAttr(name, l = 1) {
@@ -268,7 +268,7 @@ function zipAttr(name, l = 1) {
     return humpAttrMap[name]
   }
 
-  return name.toLocaleUpperCase().substr(0, l)
+  return name.toLocaleUpperCase().slice(0, l)
 }
 
 exports.miniAttr = miniAttr

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -146,7 +146,7 @@ function genExp(exp, str = 'FN.parseModelStr') {
 	expList.forEach((mds) => {
 		// The $response in the expression uses the variable directly.
 		if (mds == '$response') {
-			exp = exp.replace(new RegExp('\\' + mds, 'gm'), `${mds.substr(1)}`)
+			exp = exp.replace(new RegExp('\\' + mds, 'gm'), `${mds.slice(1)}`)
 		} else {
 			exp = exp.replace(new RegExp('\\' + mds, 'gm'), `${str}('${mds}', e.hid)`)
 		}

--- a/scripts/temp_flutter.js
+++ b/scripts/temp_flutter.js
@@ -16,7 +16,7 @@ function genExp(exp, prefix = 'FN.parseModelStr', suffix = '') {
 	expList.forEach((mds) => {
 		// The $response in the expression uses the variable directly.
 		if (mds == '$response') {
-			exp = exp.replace(new RegExp('\\' + mds, 'gm'), `${mds.substr(1)}`)
+			exp = exp.replace(new RegExp('\\' + mds, 'gm'), `${mds.slice(1)}`)
 		} else {
 			exp = exp.replace(new RegExp('\\' + mds, 'gm'), `${prefix}('\\${mds}', e.hid)${suffix}`)
 		}
@@ -74,7 +74,7 @@ function getExec(fn, params, param, hid) {
 		case 'function':
 			if (param && FX[param]) {
 				let { key, dir = '' } = FX[param]
-				let road = dir ? dir.substr(1).split('/').map(v => `['${v}']`).join('') : ''
+				let road = dir ? dir.slice(1).split('/').map(v => `['${v}']`).join('') : ''
 
 				fnexec = `FX${road}['${key}']`
 				fnargs = `e.context`
@@ -87,7 +87,7 @@ function getExec(fn, params, param, hid) {
 				if (!dir) {
 					dir = ''
 				}
-				let road = dir ? dir.substr(1).split('/').map(v => `['${v}']`).join('') : ''
+				let road = dir ? dir.slice(1).split('/').map(v => `['${v}']`).join('') : ''
 
 				fnexec = `MF${road}['${key}']`
 				fnargs = `e.context`
@@ -326,7 +326,7 @@ function genEventContent(hid, events, cloneMark, jumpCE = true) {
 				
 				break
 			case 'modelchange':
-				event += ('_' + mds.substr(1))
+				event += ('_' + mds.slice(1))
 				break
 		
 			default:
@@ -545,9 +545,9 @@ function calcEVM(id, events) {
 	let m = {}
 
 	events.forEach(event => {
-		let mdm = event.mds ? ('##' + `${event.mds.substr(1)}`) : ''
+		let mdm = event.mds ? ('##' + `${event.mds.slice(1)}`) : ''
 		let obj = {
-			fn: `__R__${id}$$${event.event + (event.mds ? ('_' + event.mds.substr(1)) : '')}__R__`,
+			fn: `__R__${id}$$${event.event + (event.mds ? ('_' + event.mds.slice(1)) : '')}__R__`,
 		}
 
 		let eventDes = ['passive', 'once', 'prevent', 'stop', 'self']

--- a/scripts/temp_mp.js
+++ b/scripts/temp_mp.js
@@ -766,7 +766,7 @@ function parseComputedExp(exp) {
 			exp = exp.replace(new RegExp('\\' + mds, 'gm'), `FN.parseModelStr('${mds}', hid)`)
 		})
 
-		return `__R__(hid) => ${exp.substr(2)}__R__`
+		return `__R__(hid) => ${exp.slice(2)}__R__`
 	}
 }
 
@@ -805,7 +805,7 @@ exports.genExpsMapContent = () => {
 				let nreg = exp.match(/\$\d+/g)
 				if (nreg) {
 					nreg.forEach(md => {
-						exp = exp.replace(md, md.substr(1))
+						exp = exp.replace(md, md.slice(1))
 					})
 				}
 				//4. Replaces the model variable expressions.

--- a/temps/flutter/lib/common/js/pubsub-js.dart
+++ b/temps/flutter/lib/common/js/pubsub-js.dart
@@ -95,7 +95,7 @@ final pubsubjs = '''
 
             // trim the hierarchy and deliver message to each level
             while( position !== -1 ){
-                topic = topic.substr( 0, position );
+                topic = topic.slice( 0, position );
                 position = topic.lastIndexOf('.');
                 deliverMessage( message, topic, data, immediateExceptions );
             }
@@ -117,7 +117,7 @@ final pubsubjs = '''
             position = topic.lastIndexOf( '.' );
 
         while ( !found && position !== -1 ){
-            topic = topic.substr( 0, position );
+            topic = topic.slice( 0, position );
             position = topic.lastIndexOf( '.' );
             found = hasDirectSubscribersFor(topic);
         }

--- a/temps/mp/src/common/_FN.js
+++ b/temps/mp/src/common/_FN.js
@@ -229,7 +229,7 @@ function parseModelStr(target, hid) {
       key = select[1]
       id = select[2]
     } else {
-      key = target.substr(1)
+      key = target.slice(1)
       id = hid
     }
 

--- a/temps/mp/src/common/anime.js
+++ b/temps/mp/src/common/anime.js
@@ -483,7 +483,7 @@ function validateValue(val, unit) {
   if (is.col(val)) return colorToRgb(val);
   if (/\s/g.test(val)) return val;
   const originalUnit = getUnit(val);
-  const unitLess = originalUnit ? val.substr(0, val.length - originalUnit.length) : val;
+  const unitLess = originalUnit ? val.slice(0, -originalUnit.length) : val;
   if (unit) return unitLess + unit;
   return unitLess;
 }

--- a/temps/mp/src/common/helper.js
+++ b/temps/mp/src/common/helper.js
@@ -83,7 +83,7 @@ export const uuid = () => {
 export const randomStr = () => {
   return Math.random()
     .toString(36)
-    .substr(2)
+    .slice(2)
 }
 
 export const T = (b = 13) => b == 13 ? Date.now() : Math.round(Date.now() / 1000)

--- a/temps/web/src/common/_FN.js
+++ b/temps/web/src/common/_FN.js
@@ -72,7 +72,7 @@ function subExpCheck(exps, v, I, hid) {
     let nreg = exp.match(/\$\d+/g)
     if (nreg) {
       nreg.forEach(md => {
-        exp = exp.replace(md, md.substr(1))
+        exp = exp.replace(md, md.slice(1))
       })
     }
 
@@ -196,7 +196,7 @@ function parseModelStr(target, hid) {
       key = select[1]
       id = select[2]
     } else {
-      key = target.substr(1)
+      key = target.slice(1)
       id = hid
     }
 
@@ -237,7 +237,7 @@ function parseModelExp(exp, hid, runtime = true) {
   })
 
   if (isComputed) {
-    return eval(exp.substr(2))
+    return eval(exp.slice(2))
   }
 
   return exp

--- a/temps/web/src/common/anime.js
+++ b/temps/web/src/common/anime.js
@@ -479,7 +479,7 @@ function validateValue(val, unit) {
   if (is.col(val)) return colorToRgb(val);
   if (/\s/g.test(val)) return val;
   const originalUnit = getUnit(val);
-  const unitLess = originalUnit ? val.substr(0, val.length - originalUnit.length) : val;
+  const unitLess = originalUnit ? val.slice(0, -originalUnit.length) : val;
   if (unit) return unitLess + unit;
   return unitLess;
 }

--- a/temps/web/src/common/helper.js
+++ b/temps/web/src/common/helper.js
@@ -83,7 +83,7 @@ export const uuid = () => {
 export const randomStr = () => {
   return Math.random()
     .toString(36)
-    .substr(2)
+    .slice(2)
 }
 
 export const T = (b = 13) => b == 13 ? Date.now() : Math.round(Date.now() / 1000)


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.